### PR TITLE
Sesuaikan Token dengan Standar JWT - IETF - RFC7519

### DIFF
--- a/application/controllers/Pelanggan.php
+++ b/application/controllers/Pelanggan.php
@@ -10,7 +10,7 @@ class Pelanggan extends Admin_Controller{
 	{
 		parent::__construct();
 
-		$this->load->model(['pelanggan_model', 'referensi_model']);
+		$this->load->model(['pelanggan_model', 'referensi_model', 'pelanggan_model_api',]);
 		$this->load->helper('url');
 		$this->load->library('pagination');
 		//if ( ! admin_logged_in()) redirect('login'); enable development
@@ -246,11 +246,8 @@ class Pelanggan extends Admin_Controller{
 
 	public function generate_token()
 	{
-		$id = $this->input->get('id');
-		$tokenData = array();
-		$tokenData['id'] = $id;
-		$tokenData['timestamp'] = now();
-		$data = AUTHORIZATION::generateToken($tokenData);
+		$id = $this->input->post('id');
+		$data = $this->pelanggan_model->generate_token($id);
 		echo json_encode($data);
 	}
 

--- a/application/models/Pelanggan_model.php
+++ b/application/models/Pelanggan_model.php
@@ -244,6 +244,17 @@ class Pelanggan_model extends CI_Model {
 		return $ada;
 	}
 
+	public function generate_token($id)
+	{
+		$payload = array(
+			"iss" => "opensid",
+			"jti" => $id,
+		);
+		$payload['timestamp'] = now();
+		$data = AUTHORIZATION::generateToken($payload);
+		return $data;
+	}
+
 }
 
 ?>

--- a/application/views/pelanggan/form.php
+++ b/application/views/pelanggan/form.php
@@ -47,14 +47,14 @@
 					<div class="form-group">
 						<label for="customerid" class="col-md-2 control-label"><span class="text-danger"></span>Customer ID</label>
 						<div class="col-md-2">
-							<input type="text" readonly name="customerid" class="form-control" placeholder="Customer ID" value="<?=$pelanggan['id']?>"/>
+							<input type="text" readonly id="customerid" name="customerid" class="form-control" placeholder="Customer ID" value="<?=$pelanggan['id']?>"/>
 							<span class="text-danger"><?= form_error('customerid');?></span>
 						</div>
 					</div>
 					<div class="form-group">
 						<label for="domain" class="col-md-2 control-label"><span class="text-danger">*</span>Domain</label>
 						<div class="col-md-5">
-							<input type="text" name="domain" class="form-control" placeholder="Contoh: cigelam.desa.id" value="<?= $this->input->post('domain') ?: $pelanggan['domain']?>"/>
+							<input type="text" id="domain" name="domain" class="form-control" placeholder="Contoh: cigelam.desa.id" value="<?= $this->input->post('domain') ?: $pelanggan['domain']?>"/>
 							<span class="text-danger"><?= form_error('domain');?></span>
 						</div>
 					</div>
@@ -189,14 +189,14 @@
   }, 5000);
 
 	$('#btn_simpan').on('click', function() {
-		var id = $("#id_desa").val();
+		var id = $('#customerid').val();
 		$.ajax({
 			url: '<?= site_url('pelanggan/generate_token')?>',
 			type: 'POST',
-			dataType: 'json',
-			data: {'id': id},
+			dataType: 'JSON',
+			data: {id:id},
 			success: function(data){
-					$('[name="token"]').val(data);
+				$('[name="token"]').val(data);
 			}
 		});
 		return false;


### PR DESCRIPTION
JWT berisi 3 bagian : Header, Payload dan Signature ( [JWT.io](https://jwt.io/introduction/) ) yang harus sesuai dengan Standar Internet Engineering Task Force (IETF) - RFC7519 - JSON Web Token (JWT) https://tools.ietf.org/html/rfc7519.

Jika token yg telah dibuat sekarang di decoded di https://jwt.io/ maka outputnya adalah : 

![jwt_nok](https://user-images.githubusercontent.com/10391199/98363666-eb81c900-2061-11eb-9187-2c074bcd3638.PNG)
Pada bagian payload ada yg tidak sesuai standar, maka perlu disesuaikan menjadi : 

![jwt_ok](https://user-images.githubusercontent.com/10391199/98363794-2257df00-2062-11eb-80cd-aced0632ae1e.PNG)

